### PR TITLE
Fix: Accidental script execution with invalid options

### DIFF
--- a/scripts/clear-build
+++ b/scripts/clear-build
@@ -3,6 +3,7 @@
 usage() {
     echo "Usage: clear-build [-mt]"
     echo "  -t: Clear build_test files"
+    exit 1
 }
 
 option_given=0

--- a/scripts/make-build
+++ b/scripts/make-build
@@ -4,6 +4,7 @@ usage() {
     echo "Usage: make-build [-mt]"
     echo "  -m: Only build main files"
     echo "  -t: Only build test files"
+    exit 1
 }
 
 option_given=0

--- a/scripts/setup-deps
+++ b/scripts/setup-deps
@@ -3,6 +3,7 @@
 usage() {
     echo "Usage: setup-deps [-t]"
     echo "  -t: Output to build_test"
+    exit 1
 }
 
 OS_NAME=$(uname)


### PR DESCRIPTION
# Pull Request

## Bug Description

Bug Description: Scripts execute even when invalid options are input.

Steps to reproduce:
1. Go through the beginning of the build process for a test build until build-configure -t 
2. Attempt to make the build by typing make-build -0t 
3. The usage case is printed, but the script will still execute the commands

Intended behavior: If options are incorrect, the usage case should be printed and the script should not execute the commands further.

## Fix Description

This PR fixes the bug by adding exit codes to the end of all usage outputs. The usage output is printed to the terminal when an invalid option is input. By adding exit codes to the end of the usage outputs, invalid options will cause the script to fail and exit without executing.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves #15 

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards
