### PR TITLE
Add grade percentage calculations

### DIFF
--- a/include/model/Course.hpp
+++ b/include/model/Course.hpp
@@ -38,7 +38,7 @@ class Course {
         std::unordered_map<std::string, Assignment> assignmentList_{};  // id -> Assignment
         static const std::unordered_map<std::string, float> gradeWeightsDefault_;   // default grade weights if not set
         std::unordered_map<std::string, float> gradeWeights_{gradeWeightsDefault_}; // weights of each assignment category
-        std::unordered_map<std::string, float> gradesByCategory_;   // map of each raw percentage grade by category
+        std::unordered_map<std::string, float> gradesByCategory_;   // average percentage grade per category for categories with at least one completed assignment
         int numCredits_{3};     // default number of credits for a class, TO-DO: allow user to override default
         float gradePct_{0.0};   // grade percentage from 0 to 100%
         std::string letterGrade_{"N/A"};

--- a/src/model/Course.cpp
+++ b/src/model/Course.cpp
@@ -100,7 +100,9 @@ void Course::validateGradeScale(const std::map<float, std::string>& gradeScale) 
     }
 }
 
-// calculate grades by category and store them in the map
+// iterates over all assignments in the Course, groups completed assignments by category, and computes
+// raw percentage grade for each category; the per-category averages will be weighted for the total 
+// grade calculation
 void Course::calculateGradesByCategory() {
     std::unordered_map<std::string, float> totals;
     std::unordered_map<std::string, unsigned int> counts;
@@ -127,10 +129,7 @@ void Course::calculateGradesByCategory() {
         }
 
         float categoryGrade = totals[categoryName] / it->second;
-        // only add to map if there is a completed assignment in the category
-        if (counts[categoryName] > 0) {
-            gradesByCategory_.emplace(categoryName, utils::floatRound(categoryGrade, 2));
-        }
+        gradesByCategory_.emplace(categoryName, utils::floatRound(categoryGrade, 2));
     }
 }
 
@@ -149,6 +148,11 @@ float Course::calculateGradePct() {
         if (gradesByCategory_.contains(category)) {
             activeWeightTotal += weight;
         }
+    }
+
+    // return early if no active categories
+    if (utils::floatEqual(activeWeightTotal, 0.0f)) {
+        return 0.0f;
     }
     
     // normalize weights and calculate overall grade

--- a/tests/unit/model/CourseTests.cpp
+++ b/tests/unit/model/CourseTests.cpp
@@ -456,6 +456,44 @@ TEST_F(CourseTest, GradePctSetterAutomaticDifferentCategories) {
     ASSERT_FLOAT_EQ(course1.getGradePct(), 89.35f);
 }
 
+TEST_F(CourseTest, GradePctSetterAutomaticAllCategories) {
+    Assignment assignment1{"Homework 1", "", "Homework", std::chrono::year_month_day{2026y/1/20}, true, 90.2f};
+    Assignment assignment2{"Midterm", "", "Midterm", std::chrono::year_month_day{2026y/2/28}, true, 88.74f};
+    Assignment assignment3{"Final Exam", "", "Final Exam", std::chrono::year_month_day{2026y/4/17}, true, 76.11f};
+    course1.addAssignment(assignment1);
+    course1.addAssignment(assignment2);
+    course1.addAssignment(assignment3);
+    ASSERT_FLOAT_EQ(course1.getGradePct(), 84.05f);
+}
+
+TEST_F(CourseTest, GradePctSetterAutomaticMultipleAssignmentsSameCategory) {
+    Assignment assignment1{"Homework 1", "", "Homework", std::chrono::year_month_day{2026y/1/20}, true, 90.2f};
+    Assignment assignment2{"Homework 2", "", "Homework", std::chrono::year_month_day{2026y/2/28}, true, 88.74f};
+    Assignment assignment3{"Homework 3", "", "Homework", std::chrono::year_month_day{2026y/4/17}, true, 76.11f};
+    course1.addAssignment(assignment1);
+    course1.addAssignment(assignment2);
+    course1.addAssignment(assignment3);
+    ASSERT_FLOAT_EQ(course1.getGradePct(), 85.02f);
+}
+
+TEST_F(CourseTest, GradePctSetterAutomaticUnevenCategorySplit) {
+    Assignment assignment1{"Homework 1", "", "Homework", std::chrono::year_month_day{2026y/1/20}, true, 90.2f};
+    Assignment assignment2{"Homework 2", "", "Homework", std::chrono::year_month_day{2026y/2/28}, true, 88.74f};
+    Assignment assignment3{"Final Exam", "", "Final Exam", std::chrono::year_month_day{2026y/4/17}, true, 76.11f};
+    course1.addAssignment(assignment1);
+    course1.addAssignment(assignment2);
+    course1.addAssignment(assignment3);
+    ASSERT_FLOAT_EQ(course1.getGradePct(), 81.25f);
+}
+
+TEST_F(CourseTest, GradePctSetterAutomaticCategoriesNonexistent) {
+    Assignment assignment1{"Quiz 1", "", "Quizzes", std::chrono::year_month_day{2026y/1/20}, true, 90.2f};
+    Assignment assignment2{"Quiz 2", "", "Quizzes", std::chrono::year_month_day{2026y/2/28}, true, 88.74f};
+    course1.addAssignment(assignment1);
+    course1.addAssignment(assignment2);
+    ASSERT_FLOAT_EQ(course1.getGradePct(), 0.0f);
+}
+
 TEST_F(CourseTest, GradePctSetterManualInvalidLow) {
     // throw out of range since input is not in range 0 to 150
     ASSERT_THROW(course1.setGradePct(-20.24f), std::out_of_range);


### PR DESCRIPTION
# Pull Request

## Description

This PR adds grade percentage calculations and normalizes the grade weights. A category is considered "active" when there is at least one completed assignment in that category. When all categories are not active, the grade weights are redistributed amongst the active categories. This ensures fairness in the grading system and is consistent with the fact that only completed assignments are counted for grading.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves #34 

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards
