### PR TITLE
Fix: Invalid term initialization with all defaults

### DIFF
--- a/src/view/CliView.cpp
+++ b/src/view/CliView.cpp
@@ -279,6 +279,7 @@ void CliView::promptAddTerm() {
             // check if date is empty (default); if not, validate input
             if (startDate == emptyDate) {
                 out_ << "Using default date." << "\n";
+                startDate = utils::defaultStartDate();
             } else {
                 utils::validateDate(startDate);
             }
@@ -541,6 +542,7 @@ void CliView::promptAddCourse() {
             // check if date is empty (default); if not, validate input
             if (startDate == emptyDate) {
                 out_ << "Using default date." << "\n";
+                startDate = utils::defaultStartDate();
             } else {
                 utils::validateDate(startDate);
             }

--- a/tests/unit/view/CliViewTests.cpp
+++ b/tests/unit/view/CliViewTests.cpp
@@ -1114,6 +1114,30 @@ TEST(CliViewTest, AddTermAlreadyExists) {
     ASSERT_TRUE(userOut.find("choose a new title") != std::string::npos);
 }
 
+TEST(CliViewTest, AddTermAllDefaults) {
+    std::istringstream input(
+        // add term
+        "A\n"
+        "Spring 2025\n"
+        "\n"
+        "\n"
+        "\n"
+        // exit
+        "X\n"
+    );
+    std::ostringstream output;
+
+    TermController controller;
+    CliView view(controller, input, output);
+    view.run();
+
+    // check for intro and invalid input message
+    const std::string userOut = output.str();
+    ASSERT_TRUE(userOut.find("Welcome to Course Companion") != std::string::npos);
+    ASSERT_TRUE(userOut.find("successfully added") != std::string::npos);
+    ASSERT_TRUE(userOut.find("term with this title already exists") == std::string::npos);
+}
+
 TEST(CliViewTest, EditTermNotFound) {
     std::istringstream input(
         // add term
@@ -2241,6 +2265,41 @@ TEST(CliViewTest, AddCourseAlreadyExists) {
     ASSERT_TRUE(userOut.find("Welcome to Course Companion") != std::string::npos);
     ASSERT_TRUE(userOut.find("course with this title already exists") != std::string::npos);
     ASSERT_TRUE(userOut.find("choose a new title") != std::string::npos);
+}
+
+TEST(CliViewTest, AddCourseAllDefaults) {
+    std::istringstream input(
+        // add term
+        "A\n"
+        "Spring 2025\n"
+        "2025-1-10\n"
+        "2025-5-23\n"
+        "yes\n"
+        // select term
+        "S\n"
+        "Spring 2025\n"
+        // add course
+        "A\n"
+        "ENGR 195A\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        "\n"
+        // exit
+        "X\n"
+    );
+    std::ostringstream output;
+
+    TermController controller;
+    CliView view(controller, input, output);
+    view.run();
+
+    // check for intro and invalid input message
+    const std::string userOut = output.str();
+    ASSERT_TRUE(userOut.find("Welcome to Course Companion") != std::string::npos);
+    ASSERT_TRUE(userOut.find("successfully added") != std::string::npos);
+    ASSERT_TRUE(userOut.find("course with this title already exists") == std::string::npos);
 }
 
 TEST(CliViewTest, EditCourseNotFound) {
@@ -3858,6 +3917,52 @@ TEST(CliViewTest, AddAssignmentAlreadyExists) {
     ASSERT_TRUE(userOut.find("Welcome to Course Companion") != std::string::npos);
     ASSERT_TRUE(userOut.find("assignment with this title already exists") != std::string::npos);
     ASSERT_TRUE(userOut.find("choose a new title") != std::string::npos);
+}
+
+TEST(CliViewTest, AddAssignmentAllDefaults) {
+    std::istringstream input(
+        // add term
+        "A\n"
+        "Spring 2025\n"
+        "2025-1-10\n"
+        "2025-5-23\n"
+        "yes\n"
+        // select term
+        "S\n"
+        "Spring 2025\n"
+        // add course
+        "A\n"
+        "ENGR 195A\n"
+        "\n"
+        "2025-1-2\n"
+        "2025-5-12\n"
+        "3\n"
+        "yes\n"
+        // select course
+        "S\n"
+        "ENGR 195A\n"
+        // add assignment
+        "A\n"
+        "Homework 1\n"
+        "\n"
+        "Homework\n"
+        "\n"
+        "\n"
+        "\n"
+        // exit
+        "X\n"
+    );
+    std::ostringstream output;
+
+    TermController controller;
+    CliView view(controller, input, output);
+    view.run();
+
+    // check for intro and invalid input message
+    const std::string userOut = output.str();
+    ASSERT_TRUE(userOut.find("Welcome to Course Companion") != std::string::npos);
+    ASSERT_TRUE(userOut.find("successfully added") != std::string::npos);
+    ASSERT_TRUE(userOut.find("assignment with this title already exists") == std::string::npos);
 }
 
 TEST(CliViewTest, EditAssignmentNotFound) {


### PR DESCRIPTION
# Pull Request

## Bug Description

Bug Description: Term fails to initialize in CliView using all defaults and a valid title. Error message in the CLI is "A term with this title already exists. Please choose a new title."

Steps to reproduce:
1. Run the main build at ./bin/CourseCompanion 
2. Click "A" for "Add term"
3. Add a valid title and press "Enter" through the rest of the term inputs. This should set the rest of the values as default.
4. The term cannot be added since there is an error thrown.
 
Intended behavior: A term should be added to the list as long as the title is unique, even if all other values are default.

## Fix Description

This PR fixes the bug by initializing a default start date for addTerm and addCourse. Previously, the default start date was uninitialized and the program set 0000-00-00 as the date, which is invalid. The addition of a default start date will allow the program to work correctly when all defaults are set.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves #66 

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards
