### PR TITLE
Fix: CliView code throws "not allowed"

### DIFF
--- a/src/view/CliView.cpp
+++ b/src/view/CliView.cpp
@@ -1048,7 +1048,7 @@ void CliView::promptEditAssignment() {
             assignmentController.editDescription(id, newDescription);
 
             // only set descriptionUpdated if old and new description don't match and if old and new description are not both whitespace
-            if (oldDescription != newDescription && !(utils::isOnlyWhitespace(oldDescription) && utils::isOnlyWhitespace(newDescription))) { {
+            if (oldDescription != newDescription && !(utils::isOnlyWhitespace(oldDescription) && utils::isOnlyWhitespace(newDescription))) {
                 resultFlags.descriptionUpdated = true;
             }
         } else if (field == "category") {


### PR DESCRIPTION
# Pull Request

## Bug Description

Bug Description: The program breaks since several lines in CliView throw "not allowed" errors.
 
Steps to reproduce:
1. Run the build with the test configuration.
2. The program fails to build due to the various errors.
 
Intended behavior: The program should run successfully, and CliView should not throw "not allowed" errors since the tests had completed before.

## Fix Description

This PR fixes the bug by deleting an extra bracket in promptEditAssignment. This bracket was added during the PR review of the last merged branch. In the future, testing will be done before pushing PR review changes to main.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves #74 

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards
