### PR TITLE
Fix: Release label doesn't exist

### DIFF
--- a/.github/workflows/promote-develop.yaml
+++ b/.github/workflows/promote-develop.yaml
@@ -43,7 +43,6 @@ jobs:
           EOF
           )" \
               --label automated \
-              --label release \
               --json number \
               -q .number)
             echo "Created PR #$PR_NUMBER"


### PR DESCRIPTION
# Pull Request

## Bug Description

Bug Description: Promotion from `develop` to `main` may fail since release label doesn't exist.
 
Steps to reproduce:
1. The workflow will promote `develop` to `main` on a weekly basis.
2. An error may occur when the workflow discovers that release does not exist.
 
Intended behavior: The `develop` branch should promote to `main` successfully and add the automation label.

## Fix Description

This PR fixes the bug by removing the release label from being added.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves #84 

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards
