### PR TITLE
Fix: Code scanning still sees 'security-scan'

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -40,12 +40,6 @@ jobs:
         run: docker run --rm course-companion:test
 
   docker:
-    if: |
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.changed_files, 'Dockerfile') ||
-      contains(github.event.pull_request.changed_files, 'src/') ||
-      contains(github.event.pull_request.changed_files, 'include/') ||
-      contains(github.event.pull_request.changed_files, 'CMakeLists.txt')
     needs: [ test ]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Pull Request

## Bug Description

Bug Description: The `security-scan` tag was removed from CI/CD previously, but it is currently still seen by GitHub. This causes each code scan to be seen as a "neutral" result.
 
Steps to reproduce:
Create any pull request in the repository.
As the PR workflows are executing, the CodeQL scan will show up as neutral due to the missing presence of `security-scan`.
 
Intended behavior: The `security-scan` job should only appear in the `codeql-analysis` file, not the `ci-cd` file.

## Fix Description

This PR fixes the bug by adding a temporary `security-scan` job, running the required actions, then pushing into `develop` and `main`. After those two branches see the job, the temporary job is removed.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor
-   [ ] Documentation

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards
