### PR TITLE
2026-02-02: weekly promotion to main

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -4,17 +4,16 @@ on:
   pull_request:
     branches: [ main, develop ]
     types: [ opened, synchronize ]
-  workflow_dispatch:  # allow manual triggering
 
   push:
     branches: [ main, develop ]
     tags:
       - 'v*'
+
+  workflow_dispatch:  # allow manual triggering
   
   schedule:
     - cron: '0 8 * * *'
-
-  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Automated weekly promotion from develop to main.

- Generated by GitHub Actions
- CI/CD and CodeQL must pass before merge