### PR TITLE
Fix: 'develop' promotion workflow doesn't wait for status checks

### DIFF
--- a/.github/workflows/promote-develop.yaml
+++ b/.github/workflows/promote-develop.yaml
@@ -56,10 +56,10 @@ jobs:
       - name: Wait for status checks
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/develop
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
-          running-workflow-name: 'promote'
+          running-workflow-name: 'Promote develop Branch'
           allowed-conclusions: success,skipped
 
       - name: Enable auto-merge


### PR DESCRIPTION
# Pull Request

## Bug Description

Bug Description: Promotion from `develop` to `main` fails since auto-merge doesn't wait for status checks.
 
Steps to reproduce:
1. The workflow will promote `develop` to `main` on a weekly basis.
2. An error may occur when the workflow tries to auto-merge but status checks are still running.
 
Intended behavior: The develop  branch should wait for status checks to complete before promoting to main .

## Fix Description

This PR fixes the bug by adding a step in the `promote-develop` workflow that waits for status checks. This step will review the progress of the status check every 10 seconds until complete.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves #107 

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards