### PR TITLE
Replace CliView entry point with QtApp entry point

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -67,6 +67,7 @@ if(NOT BUILD_TESTING)
         src/view/qt/TermView.cpp
         src/view/qt/CourseView.cpp
         src/view/qt/FormDialog.cpp
+        src/view/cli/CliView.cpp
     )
 
     target_include_directories(CourseCompanion_gui PUBLIC include)
@@ -89,8 +90,7 @@ if(NOT BUILD_TESTING)
 
     add_executable(CourseCompanion src/main.cpp)
     target_include_directories(CourseCompanion PRIVATE include)
-    target_compile_definitions(CourseCompanion PRIVATE USE_GUI)
-    target_link_libraries(CourseCompanion PRIVATE CourseCompanion_gui)
+    target_link_libraries(CourseCompanion PRIVATE CourseCompanion_gui CourseCompanion_lib)
 
     set_target_properties(CourseCompanion PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1,9 +1,19 @@
-#ifdef USE_GUI
-
 #include <QApplication>
+#include <QString>
+#include "controller/TermController.hpp"
 #include "view/qt/MainWindow.hpp"
+#include "view/cli/CliView.hpp"
 
 int main(int argc, char *argv[]) {
+    for (int i = 1; i < argc; i++) {
+        if (QString(argv[i]) == "--debug") {
+            TermController controller;
+            CliView view(controller);
+            view.run();
+            return 0;
+        }
+    }
+
     QApplication app(argc, argv);
 
     MainWindow window;
@@ -11,20 +21,3 @@ int main(int argc, char *argv[]) {
 
     return app.exec();
 }
-
-#else
-
-#include <iostream>
-#include "controller/TermController.hpp"
-#include "view/cli/CliView.hpp"
-
-int main() {
-    TermController controller;
-    CliView view(controller);
-
-    view.run();
-
-    return 0;
-}
-
-#endif

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1,12 +1,12 @@
 #include <QApplication>
-#include <QString>
+#include <string_view>
 #include "controller/TermController.hpp"
 #include "view/qt/MainWindow.hpp"
 #include "view/cli/CliView.hpp"
 
 int main(int argc, char *argv[]) {
     for (int i = 1; i < argc; i++) {
-        if (QString(argv[i]) == "--debug") {
+        if (std::string_view(argv[i]) == "--debug") {
             TermController controller;
             CliView view(controller);
             view.run();


### PR DESCRIPTION
# Pull Request

## Description

This PR changes the default behavior of the view. The GUI view is set as the default view, with the CLI view only being used in cases of debug. This changes the standard view for the user.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves #134 

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards
