### PR TITLE
CC-131: Update UI to separate Term, Course, and Assignment pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@
  
 [![Product Screenshot][product-screenshot]](https://github.com/its-geoff/course-companion)
  
-**Course Companion** is a command-line homework tracker built in C++. It lets students manage their academic life through a structured hierarchy of terms, courses, and assignments — all from the terminal.
+**Course Companion** started as a command-line homework tracker and is in the middle of growing into a full desktop app. It lets students manage their academic life through a structured hierarchy of terms, courses, and assignments, now backed by a persistent database and a Qt6 GUI that's actively replacing the original CLI as the primary interface.
+
+I'm building this solo, in whatever hours I can find between other things, so consider this a living project rather than a finished product — features land in small, versioned increments and the README gets updated as they do.
  
 Key features:
 - Organize coursework into **terms** and **courses**
@@ -72,15 +74,18 @@ Key features:
 - Enter grades as a **percentage** (`90.5`) or **points** (`17/20`) — Course Companion calculates the rest
 - Automatic **weighted grade calculation** per course, with configurable grade weights and letter grade scale
 - **GPA tracking** per term, weighted by credit hours
+- **Persistent storage** so your terms, courses, and assignments survive between sessions
+- A growing **Qt6 desktop GUI** (`MainWindow`, `TermView`, `CourseView`, `AssignmentView`) sitting alongside the original CLI
 - Persistent CI/CD pipeline with automated testing and weekly promotion from `develop` to `main`
  
-Current Version: **0.2.5 (alpha)**
+Current Version: **0.4.5 (alpha, in development)**
  
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
  
 ### Built With
  
 * [![C++][cpp-shield]][cpp-url]
+* [![Qt][qt-shield]][qt-url]
 * [![CMake][cmake-shield]][cmake-url]
 * [![Docker][docker-shield]][docker-url]
 * [![GoogleTest][gtest-shield]][gtest-url]
@@ -96,6 +101,7 @@ Current Version: **0.2.5 (alpha)**
  
 - [CMake](https://cmake.org/) 3.20+
 - [Clang](https://clang.llvm.org/) (C++20)
+- [Qt6](https://www.qt.io/) (for the GUI build)
 - [Conan](https://conan.io/) package manager
 - [Ninja](https://ninja-build.org/) build system
 - `uuid-dev` and `libmysqlcppconn-dev` (Linux)
@@ -116,10 +122,22 @@ git clone https://github.com/its-geoff/course-companion.git
 cd course-companion
 ```
  
-2. Install dependencies and configure the build:
+2. Install dependencies with Conan. This is a required step before configuring the build:
  
 ```sh
 cd build
+./setup-deps
+```
+
+To install test dependencies instead:
+
+```sh
+./setup-deps -t
+```
+ 
+3. Configure the build:
+ 
+```sh
 ./build-configure
 ```
  
@@ -129,14 +147,14 @@ To also enable test builds and coverage:
 ./build-configure -t -c
 ```
  
-3. Build the project:
+4. Build the project:
  
 ```sh
 cd build_main
 cmake --build .
 ```
  
-4. Run the application:
+5. Run the application:
  
 ```sh
 ./bin/CourseCompanion
@@ -164,7 +182,9 @@ docker run --rm course-companion:test
  
 ## Usage
  
-Course Companion uses an interactive CLI menu. On launch, you'll be guided through a hierarchy of menus:
+Course Companion is mid-migration from a CLI-only tool to a Qt6 desktop app, so both interfaces currently exist side by side while the GUI catches up to full feature parity.
+
+Either way, the workflow follows the same hierarchy:
  
 ```
 Term Menu  →  Course Menu  →  Assignment Menu
@@ -179,7 +199,7 @@ Term Menu  →  Course Menu  →  Assignment Menu
 - Enter grades as a percentage (`90.5`) or as points (`17/20`)
 - View all, completed, or incomplete assignments
  
-Grades are automatically aggregated up: assignment grades feed into course grades (weighted by category), and course grades feed into term GPA (weighted by credits).
+Grades are automatically aggregated up: assignment grades feed into course grades (weighted by category), and course grades feed into term GPA (weighted by credits). Data now persists to a database between runs, so nothing above needs to be re-entered every session.
  
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
  
@@ -190,8 +210,8 @@ Grades are automatically aggregated up: assignment grades feed into course grade
 The project follows an **MVC pattern**:
  
 - **Model** (`src/model/`) — `Assignment`, `Course`, and `Term` classes hold data and grade calculation logic.
-- **Controller** (`src/controller/`) — `AssignmentController`, `CourseController`, and `TermController` mediate between the view and models, maintaining title-to-ID mappings for case-insensitive lookups.
-- **View** (`src/view/`) — `CliView` handles all I/O, collecting user input and displaying output without containing any application logic.
+- **Controller** (`src/controller/`) — `AssignmentController`, `CourseController`, and `TermController` mediate between the views and models, maintaining title-to-ID mappings for case-insensitive lookups and propagating updates to whichever view is active.
+- **View** (`src/view/`) — `CliView` handles the original terminal I/O. The Qt6 views (`MainWindow`, `TermView`, `CourseView`, `AssignmentView`, `FormDialog`) are being built out alongside it as the GUI takes over. Neither view layer contains application logic; all of that stays in the models and controllers.
  
 Utility functions shared across the codebase live in `src/utils/utils.cpp`.
  
@@ -207,6 +227,7 @@ Configure and build the test suite:
  
 ```sh
 cd build
+./setup-deps -t
 ./build-configure -t
 cd build_test
 cmake --build .
@@ -240,9 +261,11 @@ The test suite includes unit tests for all model, controller, and utility classe
  
 ## Roadmap
  
-- [ ] Persistent data storage (database integration)
-- [ ] Configurable grade weights per course
-- [ ] Configurable grade scale per course
+- [x] Persistent data storage (database integration)
+- [x] Configurable grade weights per course
+- [x] Configurable grade scale per course
+- [ ] Full Qt6 GUI feature parity with the CLI
+- [ ] GUI branding and visual polish
 - [ ] Settings menu
 - [ ] Cross-term cumulative GPA
  
@@ -305,6 +328,8 @@ Project Link: [https://github.com/its-geoff/course-companion](https://github.com
  
 [cpp-shield]: https://img.shields.io/badge/C%2B%2B-20-00599C?style=for-the-badge&logo=cplusplus&logoColor=white
 [cpp-url]: https://en.cppreference.com/w/cpp/20
+[qt-shield]: https://img.shields.io/badge/Qt-6-41CD52?style=for-the-badge&logo=qt&logoColor=white
+[qt-url]: https://www.qt.io/
 [cmake-shield]: https://img.shields.io/badge/CMake-3.20+-064F8C?style=for-the-badge&logo=cmake&logoColor=white
 [cmake-url]: https://cmake.org/
 [docker-shield]: https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white

--- a/client/include/view/qt/AssignmentView.hpp
+++ b/client/include/view/qt/AssignmentView.hpp
@@ -6,8 +6,8 @@
  * @brief Definition of the AssignmentView class, which serves as a detail overlay for the Qt GUI.
  *
  * Shows metadata for a single selected assignment: title, description, due date, and completion
- * status. Allows grade entry (percentage or points) for incomplete assignments and grade editing
- * for completed ones. Emits backRequested when the user navigates back to CourseView.
+ * status. Allows editing those details, toggling completion status, and entering or editing a
+ * grade. Emits backRequested when the user navigates back to CourseView.
  *
  * Provides declarations only; see AssignmentView.cpp for implementations.
  */
@@ -36,6 +36,8 @@ class AssignmentView : public QWidget {
 
     private slots:
         void onSubmitGrade();
+        void onEditDetails();
+        void onToggleCompleted();
 
     private:
         void setupHeader();
@@ -44,10 +46,13 @@ class AssignmentView : public QWidget {
 
         float parseGradeInput(const QString& input, bool& ok) const;
         void  applyGradeResult(float pct);
+        void  updateStatusBadge();
 
         QVBoxLayout* mainLayout_;
 
         QPushButton* backButton_;
+        QPushButton* editButton_;
+        QPushButton* toggleCompleteButton_;
         QLabel*      titleLabel_;
         QLabel*      statusBadge_;
 
@@ -60,6 +65,8 @@ class AssignmentView : public QWidget {
         QPushButton* submitGradeButton_;
         QLabel*      gradeResultLabel_;
 
+        QString description_;
+        QString dueDate_;
         bool completed_ = false;
 };
 

--- a/client/include/view/qt/CourseView.hpp
+++ b/client/include/view/qt/CourseView.hpp
@@ -7,7 +7,8 @@
  *
  * Displays course metadata, assignment completion progress, a filterable list of assignments,
  * and a footer summary with average grade and GPA. Clicking an assignment row emits
- * assignmentSelected so MainWindow can navigate to AssignmentView.
+ * assignmentSelected so MainWindow can navigate to AssignmentView. The back button emits
+ * backRequested so MainWindow can navigate to TermView.
  *
  * Provides declarations only; see CourseView.cpp for implementations.
  */
@@ -30,9 +31,9 @@ class CourseView : public QWidget {
 
     signals:
         void assignmentSelected(const QString& assignmentTitle);
+        void backRequested();
 
     private slots:
-        void onAddCourse();
         void onAddAssignment();
         void onRemoveAssignment();
         void onFilterAll();
@@ -51,9 +52,9 @@ class CourseView : public QWidget {
 
         QVBoxLayout* mainLayout_;
 
+        QPushButton* backButton_;
         QLabel*      courseTitle_;
         QLabel*      dateRangeLabel_;
-        QPushButton* addCourseButton_;
         QPushButton* addAssignmentButton_;
         QPushButton* removeAssignmentButton_;
 

--- a/client/include/view/qt/TermView.hpp
+++ b/client/include/view/qt/TermView.hpp
@@ -7,7 +7,9 @@
  * 
  * This class shows user information from the Term perspective. It displays the current term,
  * a summary of classes, and the user's overall GPA. The class sends information to the TermController and 
- * outputs results from the TermController.
+ * outputs results from the TermController. Clicking a course row emits courseSelected so MainWindow can
+ * navigate to CourseView. Adding a term is triggered from the sidebar; onAddTerm is public so
+ * MainWindow can call it directly.
  * 
  * Note: the current Qt implementation uses placeholder data; controller wiring is planned but not yet implemented.
  * 
@@ -30,8 +32,14 @@ class TermView : public QWidget {
     public:
         explicit TermView(QWidget* parent = nullptr);
 
-    private slots:
+    signals:
+        void courseSelected(const QString& courseTitle);
+
+    public slots:
         void onAddTerm();
+
+    private slots:
+        void onAddCourse();
 
     private:
         void setupHeader();
@@ -47,7 +55,7 @@ class TermView : public QWidget {
         // header
         QLabel*      termTitle_;
         QLabel*      dateRangeLabel_;
-        QPushButton* addTermButton_;
+        QPushButton* addCourseButton_;
 
         // progress
         QProgressBar* progressBar_;

--- a/client/src/view/qt/AssignmentView.cpp
+++ b/client/src/view/qt/AssignmentView.cpp
@@ -4,13 +4,16 @@
  * @file AssignmentView.cpp
  * @brief Implementation of the AssignmentView class, which serves as a detail overlay for the Qt GUI.
  *
- * Renders metadata for one selected assignment and handles grade input. Grade input
+ * Renders metadata for one selected assignment, handles grade input, lets the user edit
+ * the assignment's details, and lets the user toggle its completion status. Grade input
  * accepts both percentage format (95.0) and point-based format (47/50); the corresponding
  * letter grade and percentage are calculated and displayed on submit.
  *
  * Note: grade-to-letter calculation uses placeholder thresholds; controller wiring
  * is planned but not yet implemented.
  */
+
+#include "view/qt/FormDialog.hpp"
 
 #include <QDebug>
 #include <QMessageBox>
@@ -72,9 +75,39 @@ void AssignmentView::setupHeader() {
     );
     statusBadge_->setAlignment(Qt::AlignVCenter);
 
+    editButton_ = new QPushButton("Edit", titleRow);
+    editButton_->setStyleSheet(
+        "QPushButton {"
+        "  font-size: 12px;"
+        "  color: #378ADD;"
+        "  background: transparent;"
+        "  border: 1px solid #378ADD;"
+        "  border-radius: 4px;"
+        "  padding: 3px 10px;"
+        "}"
+        "QPushButton:hover { background: #eef4fb; }"
+    );
+    connect(editButton_, &QPushButton::clicked, this, &AssignmentView::onEditDetails);
+
+    toggleCompleteButton_ = new QPushButton("Mark Complete", titleRow);
+    toggleCompleteButton_->setStyleSheet(
+        "QPushButton {"
+        "  font-size: 12px;"
+        "  color: #378ADD;"
+        "  background: transparent;"
+        "  border: 1px solid #378ADD;"
+        "  border-radius: 4px;"
+        "  padding: 3px 10px;"
+        "}"
+        "QPushButton:hover { background: #eef4fb; }"
+    );
+    connect(toggleCompleteButton_, &QPushButton::clicked, this, &AssignmentView::onToggleCompleted);
+
     titleLayout->addWidget(titleLabel_);
     titleLayout->addWidget(statusBadge_);
     titleLayout->addStretch();
+    titleLayout->addWidget(editButton_);
+    titleLayout->addWidget(toggleCompleteButton_);
 
     headerLayout->addWidget(topRow);
     headerLayout->addWidget(titleRow);
@@ -179,29 +212,12 @@ void AssignmentView::setupGradeSection() {
 
 void AssignmentView::loadAssignment(const QString& title, const QString& description,
                                     const QString& dueDate, bool completed, float grade) {
-    completed_ = completed;
+    completed_   = completed;
+    description_ = description;
+    dueDate_     = dueDate;
 
     titleLabel_->setText(title);
-
-    if (completed) {
-        statusBadge_->setText("Completed");
-        statusBadge_->setStyleSheet(
-            "font-size: 11px;"
-            "color: #378ADD;"
-            "background: #eef4fb;"
-            "border-radius: 4px;"
-            "padding: 2px 8px;"
-        );
-    } else {
-        statusBadge_->setText("Pending");
-        statusBadge_->setStyleSheet(
-            "font-size: 11px;"
-            "color: #888;"
-            "background: #f0f0f0;"
-            "border-radius: 4px;"
-            "padding: 2px 8px;"
-        );
-    }
+    updateStatusBadge();
 
     dueDateLabel_->setText("Due: " + dueDate);
     descriptionLabel_->setText(description.isEmpty() ? "No description." : description);
@@ -213,6 +229,30 @@ void AssignmentView::loadAssignment(const QString& title, const QString& descrip
 
     if (completed && grade >= 0.0f) {
         applyGradeResult(grade);
+    }
+}
+
+void AssignmentView::updateStatusBadge() {
+    if (completed_) {
+        statusBadge_->setText("Completed");
+        statusBadge_->setStyleSheet(
+            "font-size: 11px;"
+            "color: #378ADD;"
+            "background: #eef4fb;"
+            "border-radius: 4px;"
+            "padding: 2px 8px;"
+        );
+        toggleCompleteButton_->setText("Mark Incomplete");
+    } else {
+        statusBadge_->setText("Pending");
+        statusBadge_->setStyleSheet(
+            "font-size: 11px;"
+            "color: #888;"
+            "background: #f0f0f0;"
+            "border-radius: 4px;"
+            "padding: 2px 8px;"
+        );
+        toggleCompleteButton_->setText("Mark Complete");
     }
 }
 
@@ -289,4 +329,43 @@ void AssignmentView::onSubmitGrade() {
 
     // TODO: wire to AssignmentController::addGrade / editGrade once controller is connected
     qDebug() << "Save grade:" << pct;
+}
+
+void AssignmentView::onToggleCompleted() {
+    completed_ = !completed_;
+    updateStatusBadge();
+    gradeSectionTitle_->setText(completed_ ? "EDIT GRADE" : "ENTER GRADE");
+
+    // TODO: wire to AssignmentController once it exposes a direct completion toggle
+    qDebug() << "Toggle completed:" << completed_;
+}
+
+void AssignmentView::onEditDetails() {
+    QDate parsedDueDate = QDate::fromString(dueDate_, "MMM d, yyyy");
+    if (!parsedDueDate.isValid())
+        parsedDueDate = QDate::currentDate();
+
+    std::vector<FieldDef> fields = {
+        { "title",   "Title",       FieldDef::Type::Text,         titleLabel_->text() },
+        { "desc",    "Description", FieldDef::Type::OptionalText, description_         },
+        { "dueDate", "Due Date",    FieldDef::Type::Date,         parsedDueDate        },
+    };
+
+    FormDialog dlg("Edit Assignment", fields, this);
+    if (dlg.exec() != QDialog::Accepted)
+        return;
+
+    QString newTitle = dlg.textValue("title");
+    QString newDesc  = dlg.textValue("desc");
+    QDate   newDate  = dlg.dateValue("dueDate");
+
+    titleLabel_->setText(newTitle);
+    description_ = newDesc;
+    dueDate_      = newDate.toString("MMM d, yyyy");
+
+    descriptionLabel_->setText(newDesc.isEmpty() ? "No description." : newDesc);
+    dueDateLabel_->setText("Due: " + dueDate_);
+
+    // TODO: wire to AssignmentController::editTitle / editDescription / editDueDate once connected
+    qDebug() << "Edit Assignment:" << newTitle << newDesc << dueDate_;
 }

--- a/client/src/view/qt/AssignmentView.cpp
+++ b/client/src/view/qt/AssignmentView.cpp
@@ -336,6 +336,11 @@ void AssignmentView::onToggleCompleted() {
     updateStatusBadge();
     gradeSectionTitle_->setText(completed_ ? "EDIT GRADE" : "ENTER GRADE");
 
+    if (!completed_) {
+        gradeInput_->clear();
+        gradeResultLabel_->hide();
+    }
+
     // TODO: wire to AssignmentController once it exposes a direct completion toggle
     qDebug() << "Toggle completed:" << completed_;
 }

--- a/client/src/view/qt/AssignmentView.cpp
+++ b/client/src/view/qt/AssignmentView.cpp
@@ -63,7 +63,7 @@ void AssignmentView::setupHeader() {
     titleLayout->setSpacing(12);
 
     titleLabel_ = new QLabel("Assignment Title", titleRow);
-    titleLabel_->setStyleSheet("font-size: 22px; font-weight: 500;");
+    titleLabel_->setStyleSheet("font-size: 22px; font-weight: 500; color: #1a1a1a;");
 
     statusBadge_ = new QLabel("Pending", titleRow);
     statusBadge_->setStyleSheet(

--- a/client/src/view/qt/CourseView.cpp
+++ b/client/src/view/qt/CourseView.cpp
@@ -88,11 +88,7 @@ void CourseView::setupHeader() {
     titleLayout->setSpacing(8);
 
     courseTitle_ = new QLabel("Data Structures", titleRow);
-    courseTitle_->setStyleSheet("font-size: 22px; font-weight: 500;");
-
-    auto* courseTypeLabel = new QLabel("Course", titleRow);
-    courseTypeLabel->setStyleSheet("font-size: 12px; color: #888; padding-top: 6px;");
-    courseTypeLabel->setAlignment(Qt::AlignBottom);
+    courseTitle_->setStyleSheet("font-size: 22px; font-weight: 500; color: #1a1a1a;");
 
     addAssignmentButton_ = new QPushButton("+ Add", titleRow);
     addAssignmentButton_->setStyleSheet(
@@ -123,16 +119,19 @@ void CourseView::setupHeader() {
     connect(removeAssignmentButton_, &QPushButton::clicked, this, &CourseView::onRemoveAssignment);
 
     titleLayout->addWidget(courseTitle_);
-    titleLayout->addWidget(courseTypeLabel);
     titleLayout->addStretch();
     titleLayout->addWidget(addAssignmentButton_);
     titleLayout->addWidget(removeAssignmentButton_);
+
+    auto* courseTypeLabel = new QLabel("Course", header);
+    courseTypeLabel->setStyleSheet("font-size: 14px; font-weight: 500; color: #888;");
 
     dateRangeLabel_ = new QLabel("Aug 26 - Dec 20, 2024", header);
     dateRangeLabel_->setStyleSheet("font-size: 13px; color: #666;");
 
     headerLayout->addWidget(topRow);
     headerLayout->addWidget(titleRow);
+    headerLayout->addWidget(courseTypeLabel);
     headerLayout->addWidget(dateRangeLabel_);
 
     mainLayout_->addWidget(header);
@@ -272,7 +271,7 @@ void CourseView::addAssignmentRow(const QString& name, const QString& sub,
     textColLayout->setSpacing(2);
 
     auto* nameLabel = new QLabel(name, textCol);
-    nameLabel->setStyleSheet("font-size: 13px; font-weight: 500;");
+    nameLabel->setStyleSheet("font-size: 13px; font-weight: 500; color: #1a1a1a;");
 
     auto* subLabel = new QLabel(sub, textCol);
     subLabel->setStyleSheet("font-size: 11px; color: #999;");
@@ -292,7 +291,7 @@ void CourseView::addAssignmentRow(const QString& name, const QString& sub,
         gradeColLayout->setAlignment(Qt::AlignRight);
 
         auto* pctLabel = new QLabel(pct, gradeCol);
-        pctLabel->setStyleSheet("font-size: 14px; font-weight: 500;");
+        pctLabel->setStyleSheet("font-size: 14px; font-weight: 500; color: #1a1a1a;");
         pctLabel->setAlignment(Qt::AlignRight);
 
         auto* letterLabel = new QLabel(letter, gradeCol);
@@ -308,7 +307,7 @@ void CourseView::addAssignmentRow(const QString& name, const QString& sub,
         gpaColLayout->setSpacing(2);
 
         auto* gpaVal = new QLabel(gpa, gpaCol);
-        gpaVal->setStyleSheet("font-size: 14px; font-weight: 500;");
+        gpaVal->setStyleSheet("font-size: 14px; font-weight: 500; color: #1a1a1a;");
         gpaVal->setAlignment(Qt::AlignRight);
 
         auto* gpaLbl = new QLabel("GPA pts", gpaCol);
@@ -362,7 +361,7 @@ void CourseView::setupFooter() {
     avgLbl->setStyleSheet("font-size: 11px; color: #999;");
 
     avgGradeLabel_ = new QLabel("91.5%", avgSection);
-    avgGradeLabel_->setStyleSheet("font-size: 16px; font-weight: 500;");
+    avgGradeLabel_->setStyleSheet("font-size: 16px; font-weight: 500; color: #1a1a1a;");
 
     avgLayout->addWidget(avgLbl);
     avgLayout->addWidget(avgGradeLabel_);
@@ -376,7 +375,7 @@ void CourseView::setupFooter() {
     gpaLbl->setStyleSheet("font-size: 11px; color: #999;");
 
     gpaLabel_ = new QLabel("3.74", gpaSection);
-    gpaLabel_->setStyleSheet("font-size: 16px; font-weight: 500;");
+    gpaLabel_->setStyleSheet("font-size: 16px; font-weight: 500; color: #1a1a1a;");
 
     gpaLayout->addWidget(gpaLbl);
     gpaLayout->addWidget(gpaLabel_);

--- a/client/src/view/qt/CourseView.cpp
+++ b/client/src/view/qt/CourseView.cpp
@@ -6,6 +6,7 @@
  *
  * Displays course metadata, a filterable assignment list with add/remove support,
  * and a grade summary footer. Clicking an assignment row emits assignmentSelected.
+ * The back button emits backRequested.
  *
  * Note: the current Qt implementation uses placeholder data; controller wiring is planned but not yet implemented.
  */
@@ -58,7 +59,28 @@ void CourseView::setupHeader() {
     auto* header       = new QWidget(this);
     auto* headerLayout = new QVBoxLayout(header);
     headerLayout->setContentsMargins(0, 0, 0, 0);
-    headerLayout->setSpacing(4);
+    headerLayout->setSpacing(8);
+
+    auto* topRow    = new QWidget(header);
+    auto* topLayout = new QHBoxLayout(topRow);
+    topLayout->setContentsMargins(0, 0, 0, 0);
+    topLayout->setSpacing(8);
+
+    backButton_ = new QPushButton("← Back", topRow);
+    backButton_->setStyleSheet(
+        "QPushButton {"
+        "  font-size: 12px;"
+        "  color: #666;"
+        "  background: transparent;"
+        "  border: none;"
+        "  padding: 0;"
+        "}"
+        "QPushButton:hover { color: #378ADD; }"
+    );
+    connect(backButton_, &QPushButton::clicked, this, &CourseView::backRequested);
+
+    topLayout->addWidget(backButton_);
+    topLayout->addStretch();
 
     auto* titleRow    = new QWidget(header);
     auto* titleLayout = new QHBoxLayout(titleRow);
@@ -71,20 +93,6 @@ void CourseView::setupHeader() {
     auto* courseTypeLabel = new QLabel("Course", titleRow);
     courseTypeLabel->setStyleSheet("font-size: 12px; color: #888; padding-top: 6px;");
     courseTypeLabel->setAlignment(Qt::AlignBottom);
-
-    addCourseButton_ = new QPushButton("+ Add Course", titleRow);
-    addCourseButton_->setStyleSheet(
-        "QPushButton {"
-        "  font-size: 12px;"
-        "  color: #378ADD;"
-        "  background: transparent;"
-        "  border: 1px solid #378ADD;"
-        "  border-radius: 4px;"
-        "  padding: 3px 10px;"
-        "}"
-        "QPushButton:hover { background: #eef4fb; }"
-    );
-    connect(addCourseButton_, &QPushButton::clicked, this, &CourseView::onAddCourse);
 
     addAssignmentButton_ = new QPushButton("+ Add", titleRow);
     addAssignmentButton_->setStyleSheet(
@@ -117,13 +125,13 @@ void CourseView::setupHeader() {
     titleLayout->addWidget(courseTitle_);
     titleLayout->addWidget(courseTypeLabel);
     titleLayout->addStretch();
-    titleLayout->addWidget(addCourseButton_);
     titleLayout->addWidget(addAssignmentButton_);
     titleLayout->addWidget(removeAssignmentButton_);
 
     dateRangeLabel_ = new QLabel("Aug 26 - Dec 20, 2024", header);
     dateRangeLabel_->setStyleSheet("font-size: 13px; color: #666;");
 
+    headerLayout->addWidget(topRow);
     headerLayout->addWidget(titleRow);
     headerLayout->addWidget(dateRangeLabel_);
 
@@ -378,30 +386,6 @@ void CourseView::setupFooter() {
     footerLayout->addWidget(gpaSection);
 
     mainLayout_->addWidget(footer);
-}
-
-void CourseView::onAddCourse() {
-    std::vector<FieldDef> fields = {
-        { "title",       "Title",          FieldDef::Type::Text,         QString{}                        },
-        { "description", "Description",    FieldDef::Type::OptionalText, QString{}                        },
-        { "startDate",   "Start Date",     FieldDef::Type::Date,         QDate::currentDate()             },
-        { "endDate",     "End Date",       FieldDef::Type::Date,         QDate::currentDate().addMonths(4) },
-        { "numCredits",  "Credits",        FieldDef::Type::Integer,      3                                },
-        { "active",      "Current course", FieldDef::Type::Bool,         true                             },
-    };
-
-    FormDialog dlg("Add Course", fields, this);
-    if (dlg.exec() != QDialog::Accepted)
-        return;
-
-    // TODO: wire to CourseController::addCourse once controller is connected
-    qDebug() << "Add Course:"
-             << dlg.textValue("title")
-             << dlg.textValue("description")
-             << dlg.dateValue("startDate").toString("yyyy-MM-dd")
-             << dlg.dateValue("endDate").toString("yyyy-MM-dd")
-             << dlg.intValue("numCredits")
-             << dlg.boolValue("active");
 }
 
 void CourseView::onAddAssignment() {

--- a/client/src/view/qt/MainWindow.cpp
+++ b/client/src/view/qt/MainWindow.cpp
@@ -64,6 +64,8 @@ void MainWindow::setupUi() {
     auto* termCardOverlay = new QPushButton(termCard);
     termCardOverlay->setFlat(true);
     termCardOverlay->setCursor(Qt::PointingHandCursor);
+    termCardOverlay->setFocusPolicy(Qt::NoFocus);
+    termCardOverlay->setAccessibleName(QString("Open term %1").arg(termCardTitle->text()));
     termCardOverlay->setStyleSheet(
         "QPushButton { background: transparent; border: none; border-radius: 8px; }"
         "QPushButton:hover { background: rgba(55, 138, 221, 0.06); }"

--- a/client/src/view/qt/MainWindow.cpp
+++ b/client/src/view/qt/MainWindow.cpp
@@ -11,6 +11,10 @@
  * app logic. The class calls instances of other windows as the main driver behind the GUI.
  */
 
+#include <QDebug>
+#include <QFrame>
+#include <QStackedLayout>
+
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent) {
     setupUi();
@@ -32,12 +36,58 @@ void MainWindow::setupUi() {
     sidebarLayout->setSpacing(4);
 
     auto* sidebarLabel = new QLabel("Course Companion", sidebar_);
-    auto* termBtn      = new QPushButton("Fall 2024", sidebar_);
-    auto* courseBtn    = new QPushButton("Data Structures", sidebar_);
+
+    // term details card: clicking it returns to the term page
+    auto* termCard      = new QFrame(sidebar_);
+    auto* termCardStack = new QStackedLayout(termCard);
+    termCardStack->setStackingMode(QStackedLayout::StackAll);
+    termCard->setStyleSheet(
+        "QFrame { background: white; border: 0.5px solid #e0e0e0; border-radius: 8px; }"
+    );
+
+    auto* termCardContent = new QWidget(termCard);
+    auto* termCardLayout  = new QVBoxLayout(termCardContent);
+    termCardLayout->setContentsMargins(10, 8, 10, 8);
+    termCardLayout->setSpacing(2);
+
+    auto* termCardTitle = new QLabel("Fall 2024", termCardContent);
+    termCardTitle->setStyleSheet("font-size: 13px; font-weight: 500;");
+
+    auto* termCardDates = new QLabel("Aug 26 - Dec 20, 2024", termCardContent);
+    termCardDates->setStyleSheet("font-size: 10px; color: #999;");
+
+    termCardLayout->addWidget(termCardTitle);
+    termCardLayout->addWidget(termCardDates);
+
+    auto* termCardOverlay = new QPushButton(termCard);
+    termCardOverlay->setFlat(true);
+    termCardOverlay->setCursor(Qt::PointingHandCursor);
+    termCardOverlay->setStyleSheet(
+        "QPushButton { background: transparent; border: none; border-radius: 8px; }"
+        "QPushButton:hover { background: rgba(55, 138, 221, 0.06); }"
+    );
+
+    termCardStack->addWidget(termCardContent);
+    termCardStack->addWidget(termCardOverlay);
+    termCardStack->setCurrentIndex(1);
+
+    auto* addTermButton = new QPushButton("+ Add Term", sidebar_);
+    addTermButton->setStyleSheet(
+        "QPushButton {"
+        "  font-size: 12px;"
+        "  color: #378ADD;"
+        "  background: transparent;"
+        "  border: 1px solid #378ADD;"
+        "  border-radius: 4px;"
+        "  padding: 4px 0;"
+        "}"
+        "QPushButton:hover { background: #eef4fb; }"
+    );
 
     sidebarLayout->addWidget(sidebarLabel);
-    sidebarLayout->addWidget(termBtn);
-    sidebarLayout->addWidget(courseBtn);
+    sidebarLayout->addSpacing(8);
+    sidebarLayout->addWidget(termCard);
+    sidebarLayout->addWidget(addTermButton);
     sidebarLayout->addStretch();
 
     auto* termPage       = new TermView();
@@ -58,8 +108,20 @@ void MainWindow::setupUi() {
     setWindowTitle("Course Companion");
     resize(900, 700);
 
-    connect(termBtn,   &QPushButton::clicked, this, [this]() { stack_->setCurrentIndex(0); });
-    connect(courseBtn, &QPushButton::clicked, this, [this]() { stack_->setCurrentIndex(1); });
+    connect(termCardOverlay, &QPushButton::clicked, this, [this]() { stack_->setCurrentIndex(0); });
+    connect(addTermButton, &QPushButton::clicked, termPage, &TermView::onAddTerm);
+
+    connect(termPage, &TermView::courseSelected, this,
+        [this](const QString& title) {
+            // TODO: load real course data from controller once wiring lands
+            qDebug() << "Course selected:" << title;
+            stack_->setCurrentIndex(1);
+        }
+    );
+
+    connect(coursePage, &CourseView::backRequested, this,
+        [this]() { stack_->setCurrentIndex(0); }
+    );
 
     connect(coursePage, &CourseView::assignmentSelected, this,
         [this, assignmentPage](const QString& title) {

--- a/client/src/view/qt/MainWindow.cpp
+++ b/client/src/view/qt/MainWindow.cpp
@@ -36,9 +36,11 @@ void MainWindow::setupUi() {
     sidebarLayout->setSpacing(4);
 
     auto* sidebarLabel = new QLabel("Course Companion", sidebar_);
+    sidebarLabel->setStyleSheet("font-size: 13px; font-weight: 600; color: #333;");
 
     // term details card: clicking it returns to the term page
     auto* termCard      = new QFrame(sidebar_);
+    termCard->setFixedHeight(52);
     auto* termCardStack = new QStackedLayout(termCard);
     termCardStack->setStackingMode(QStackedLayout::StackAll);
     termCard->setStyleSheet(
@@ -51,7 +53,7 @@ void MainWindow::setupUi() {
     termCardLayout->setSpacing(2);
 
     auto* termCardTitle = new QLabel("Fall 2024", termCardContent);
-    termCardTitle->setStyleSheet("font-size: 13px; font-weight: 500;");
+    termCardTitle->setStyleSheet("font-size: 13px; font-weight: 500; color: #1a1a1a;");
 
     auto* termCardDates = new QLabel("Aug 26 - Dec 20, 2024", termCardContent);
     termCardDates->setStyleSheet("font-size: 10px; color: #999;");

--- a/client/src/view/qt/TermView.cpp
+++ b/client/src/view/qt/TermView.cpp
@@ -5,7 +5,8 @@
  * @brief Implementation of the TermView class, which serves as a secondary page for the Qt GUI.
  *
  * This class displays information received from the TermController. The term name is shown,
- * along with course grades, timelines, and the overall GPA from the term.
+ * along with course grades, timelines, and the overall GPA from the term. Clicking a course
+ * card emits courseSelected so MainWindow can navigate to CourseView.
  *
  * Note: the current Qt implementation uses placeholder data; controller wiring is planned but not yet implemented.
  */
@@ -15,6 +16,7 @@
 #include <QDate>
 #include <QDebug>
 #include <QPushButton>
+#include <QStackedLayout>
 
 TermView::TermView(QWidget* parent) : QWidget(parent) {
     mainLayout_ = new QVBoxLayout(this);
@@ -47,8 +49,8 @@ void TermView::setupHeader() {
     termTypeLabel->setStyleSheet("font-size: 12px; color: #888; padding-top: 6px;");
     termTypeLabel->setAlignment(Qt::AlignBottom);  // align to baseline of title
 
-    addTermButton_ = new QPushButton("+ Add Term", titleRow);
-    addTermButton_->setStyleSheet(
+    addCourseButton_ = new QPushButton("+ Add Course", titleRow);
+    addCourseButton_->setStyleSheet(
         "QPushButton {"
         "  font-size: 12px;"
         "  color: #378ADD;"
@@ -59,12 +61,12 @@ void TermView::setupHeader() {
         "}"
         "QPushButton:hover { background: #eef4fb; }"
     );
-    connect(addTermButton_, &QPushButton::clicked, this, &TermView::onAddTerm);
+    connect(addCourseButton_, &QPushButton::clicked, this, &TermView::onAddCourse);
 
     titleLayout->addWidget(termTitle_);
     titleLayout->addWidget(termTypeLabel);
     titleLayout->addStretch();  // push both labels to the left
-    titleLayout->addWidget(addTermButton_);
+    titleLayout->addWidget(addCourseButton_);
 
     dateRangeLabel_ = new QLabel("Aug 26 - Dec 20, 2024", header);
     dateRangeLabel_->setStyleSheet("font-size: 13px; color: #666;");
@@ -161,19 +163,24 @@ void TermView::setupCourseList() {
 void TermView::addCourseRow(const QString& name, const QString& sub,
                              const QString& pct, const QString& letter,
                              const QString& gpa) {
-    auto* row       = new QFrame();
-    auto* rowLayout = new QHBoxLayout(row);
-    rowLayout->setContentsMargins(14, 10, 14, 10);
+    // outer card: QStackedLayout lets the click overlay and content share the same rect
+    auto* card        = new QFrame();
+    auto* stackLayout = new QStackedLayout(card);
+    stackLayout->setStackingMode(QStackedLayout::StackAll);
 
-    row->setStyleSheet(
+    card->setStyleSheet(
         "QFrame { background: white; border: 0.5px solid #e0e0e0; border-radius: 8px; }"
     );
 
-    auto* dot = new QWidget(row);
+    auto* content   = new QWidget(card);
+    auto* rowLayout = new QHBoxLayout(content);
+    rowLayout->setContentsMargins(14, 10, 14, 10);
+
+    auto* dot = new QWidget(content);
     dot->setFixedSize(8, 8);
     dot->setStyleSheet("background: #378ADD; border-radius: 4px;");
 
-    auto* textCol       = new QWidget(row);
+    auto* textCol       = new QWidget(content);
     auto* textColLayout = new QVBoxLayout(textCol);
     textColLayout->setContentsMargins(0, 0, 0, 0);
     textColLayout->setSpacing(2);
@@ -187,13 +194,13 @@ void TermView::addCourseRow(const QString& name, const QString& sub,
     textColLayout->addWidget(nameLabel);
     textColLayout->addWidget(subLabel);
 
-    auto* gradeCol       = new QWidget(row);
+    auto* gradeCol       = new QWidget(content);
     auto* gradeColLayout = new QVBoxLayout(gradeCol);
     gradeColLayout->setContentsMargins(0, 0, 0, 0);
     gradeColLayout->setSpacing(2);
     gradeColLayout->setAlignment(Qt::AlignRight);
 
-    auto* pctLabel    = new QLabel(pct, gradeCol);
+    auto* pctLabel = new QLabel(pct, gradeCol);
     pctLabel->setStyleSheet("font-size: 14px; font-weight: 500;");
     pctLabel->setAlignment(Qt::AlignRight);
 
@@ -204,16 +211,16 @@ void TermView::addCourseRow(const QString& name, const QString& sub,
     gradeColLayout->addWidget(pctLabel);
     gradeColLayout->addWidget(letterLabel);
 
-    auto* gpaCol       = new QWidget(row);
+    auto* gpaCol       = new QWidget(content);
     auto* gpaColLayout = new QVBoxLayout(gpaCol);
     gpaColLayout->setContentsMargins(0, 0, 0, 0);
     gpaColLayout->setSpacing(2);
 
-    auto* gpaVal   = new QLabel(gpa, gpaCol);
+    auto* gpaVal = new QLabel(gpa, gpaCol);
     gpaVal->setStyleSheet("font-size: 14px; font-weight: 500;");
     gpaVal->setAlignment(Qt::AlignRight);
 
-    auto* gpaLbl   = new QLabel("GPA pts", gpaCol);
+    auto* gpaLbl = new QLabel("GPA pts", gpaCol);
     gpaLbl->setStyleSheet("font-size: 11px; color: #999;");
     gpaLbl->setAlignment(Qt::AlignRight);
 
@@ -227,7 +234,23 @@ void TermView::addCourseRow(const QString& name, const QString& sub,
     rowLayout->addSpacing(16);
     rowLayout->addWidget(gpaCol);
 
-    courseListLayout_->addWidget(row);
+    // click overlay: transparent button on top of content, fills the card
+    auto* clickOverlay = new QPushButton(card);
+    clickOverlay->setFlat(true);
+    clickOverlay->setCursor(Qt::PointingHandCursor);
+    clickOverlay->setStyleSheet(
+        "QPushButton { background: transparent; border: none; border-radius: 8px; }"
+        "QPushButton:hover { background: rgba(55, 138, 221, 0.06); }"
+    );
+    connect(clickOverlay, &QPushButton::clicked, this, [this, name]() {
+        emit courseSelected(name);
+    });
+
+    stackLayout->addWidget(content);
+    stackLayout->addWidget(clickOverlay);
+    stackLayout->setCurrentIndex(1);
+
+    courseListLayout_->addWidget(card);
 }
 
 
@@ -291,5 +314,29 @@ void TermView::onAddTerm() {
              << dlg.textValue("title")
              << dlg.dateValue("startDate").toString("yyyy-MM-dd")
              << dlg.dateValue("endDate").toString("yyyy-MM-dd")
+             << dlg.boolValue("active");
+}
+
+void TermView::onAddCourse() {
+    std::vector<FieldDef> fields = {
+        { "title",       "Title",          FieldDef::Type::Text,         QString{}                        },
+        { "description", "Description",    FieldDef::Type::OptionalText, QString{}                        },
+        { "startDate",   "Start Date",     FieldDef::Type::Date,         QDate::currentDate()             },
+        { "endDate",     "End Date",       FieldDef::Type::Date,         QDate::currentDate().addMonths(4) },
+        { "numCredits",  "Credits",        FieldDef::Type::Integer,      3                                },
+        { "active",      "Current course", FieldDef::Type::Bool,         true                             },
+    };
+
+    FormDialog dlg("Add Course", fields, this);
+    if (dlg.exec() != QDialog::Accepted)
+        return;
+
+    // TODO: wire to CourseController::addCourse once controller is connected
+    qDebug() << "Add Course:"
+             << dlg.textValue("title")
+             << dlg.textValue("description")
+             << dlg.dateValue("startDate").toString("yyyy-MM-dd")
+             << dlg.dateValue("endDate").toString("yyyy-MM-dd")
+             << dlg.intValue("numCredits")
              << dlg.boolValue("active");
 }

--- a/client/src/view/qt/TermView.cpp
+++ b/client/src/view/qt/TermView.cpp
@@ -237,6 +237,8 @@ void TermView::addCourseRow(const QString& name, const QString& sub,
     auto* clickOverlay = new QPushButton(card);
     clickOverlay->setFlat(true);
     clickOverlay->setCursor(Qt::PointingHandCursor);
+    clickOverlay->setFocusPolicy(Qt::NoFocus);
+    clickOverlay->setAccessibleName(QString("Open course %1").arg(name));
     clickOverlay->setStyleSheet(
         "QPushButton { background: transparent; border: none; border-radius: 8px; }"
         "QPushButton:hover { background: rgba(55, 138, 221, 0.06); }"

--- a/client/src/view/qt/TermView.cpp
+++ b/client/src/view/qt/TermView.cpp
@@ -43,11 +43,7 @@ void TermView::setupHeader() {
     titleLayout->setSpacing(8);
 
     termTitle_ = new QLabel("Fall 2024", titleRow);
-    termTitle_->setStyleSheet("font-size: 22px; font-weight: 500;");
-
-    auto* termTypeLabel = new QLabel("Term", titleRow);
-    termTypeLabel->setStyleSheet("font-size: 12px; color: #888; padding-top: 6px;");
-    termTypeLabel->setAlignment(Qt::AlignBottom);  // align to baseline of title
+    termTitle_->setStyleSheet("font-size: 22px; font-weight: 500; color: #1a1a1a;");
 
     addCourseButton_ = new QPushButton("+ Add Course", titleRow);
     addCourseButton_->setStyleSheet(
@@ -64,14 +60,17 @@ void TermView::setupHeader() {
     connect(addCourseButton_, &QPushButton::clicked, this, &TermView::onAddCourse);
 
     titleLayout->addWidget(termTitle_);
-    titleLayout->addWidget(termTypeLabel);
-    titleLayout->addStretch();  // push both labels to the left
+    titleLayout->addStretch();
     titleLayout->addWidget(addCourseButton_);
+
+    auto* termTypeLabel = new QLabel("Term", header);
+    termTypeLabel->setStyleSheet("font-size: 14px; font-weight: 500; color: #888;");
 
     dateRangeLabel_ = new QLabel("Aug 26 - Dec 20, 2024", header);
     dateRangeLabel_->setStyleSheet("font-size: 13px; color: #666;");
 
     headerLayout->addWidget(titleRow);
+    headerLayout->addWidget(termTypeLabel);
     headerLayout->addWidget(dateRangeLabel_);
 
     mainLayout_->addWidget(header);
@@ -186,7 +185,7 @@ void TermView::addCourseRow(const QString& name, const QString& sub,
     textColLayout->setSpacing(2);
 
     auto* nameLabel = new QLabel(name, textCol);
-    nameLabel->setStyleSheet("font-size: 13px; font-weight: 500;");
+    nameLabel->setStyleSheet("font-size: 13px; font-weight: 500; color: #1a1a1a;");
 
     auto* subLabel = new QLabel(sub, textCol);
     subLabel->setStyleSheet("font-size: 11px; color: #999;");
@@ -201,7 +200,7 @@ void TermView::addCourseRow(const QString& name, const QString& sub,
     gradeColLayout->setAlignment(Qt::AlignRight);
 
     auto* pctLabel = new QLabel(pct, gradeCol);
-    pctLabel->setStyleSheet("font-size: 14px; font-weight: 500;");
+    pctLabel->setStyleSheet("font-size: 14px; font-weight: 500; color: #1a1a1a;");
     pctLabel->setAlignment(Qt::AlignRight);
 
     auto* letterLabel = new QLabel(letter, gradeCol);
@@ -217,7 +216,7 @@ void TermView::addCourseRow(const QString& name, const QString& sub,
     gpaColLayout->setSpacing(2);
 
     auto* gpaVal = new QLabel(gpa, gpaCol);
-    gpaVal->setStyleSheet("font-size: 14px; font-weight: 500;");
+    gpaVal->setStyleSheet("font-size: 14px; font-weight: 500; color: #1a1a1a;");
     gpaVal->setAlignment(Qt::AlignRight);
 
     auto* gpaLbl = new QLabel("GPA pts", gpaCol);
@@ -271,7 +270,7 @@ void TermView::setupFooter() {
     avgLbl->setStyleSheet("font-size: 11px; color: #999;");
 
     avgGradeLabel_ = new QLabel("89.1%", avgSection);
-    avgGradeLabel_->setStyleSheet("font-size: 16px; font-weight: 500;");
+    avgGradeLabel_->setStyleSheet("font-size: 16px; font-weight: 500; color: #1a1a1a;");
 
     avgLayout->addWidget(avgLbl);
     avgLayout->addWidget(avgGradeLabel_);
@@ -285,7 +284,7 @@ void TermView::setupFooter() {
     gpaLbl->setStyleSheet("font-size: 11px; color: #999;");
 
     gpaLabel_ = new QLabel("3.52", gpaSection);
-    gpaLabel_->setStyleSheet("font-size: 16px; font-weight: 500;");
+    gpaLabel_->setStyleSheet("font-size: 16px; font-weight: 500; color: #1a1a1a;");
 
     gpaLayout->addWidget(gpaLbl);
     gpaLayout->addWidget(gpaLabel_);


### PR DESCRIPTION
# Pull Request

## Description

This PR separates the Term, Course, and Assignment pages. The full list of Terms is on the left sidebar. The Term page leads to different Courses. Each Course page leads to different Assignments. Each assignment has its own page where the user can customize grades and information. This ensures separation between each class type and makes the experience better for the user.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves [CC-131](https://geoffreyagustin.atlassian.net/browse/CC-131)

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards


[CC-131]: https://geoffreyagustin.atlassian.net/browse/CC-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ