### PR TITLE
CC-134: Enable qt widget view code course companion gui to build under BUILD_TESTING

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -69,39 +69,39 @@ function(enable_coverage target)
     endif()
 endfunction()
 
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
+
+add_library(CourseCompanion_gui OBJECT
+    src/view/cli/CliView.cpp
+    src/view/qt/AssignmentView.cpp
+    src/view/qt/CourseView.cpp
+    src/view/qt/FormDialog.cpp
+    src/view/qt/MainWindow.cpp
+    src/view/qt/TermView.cpp
+)
+
+target_include_directories(CourseCompanion_gui PUBLIC include)
+
+set_target_properties(CourseCompanion_gui PROPERTIES
+    AUTOMOC_MOC_OPTIONS ""
+)
+target_sources(CourseCompanion_gui PRIVATE
+    include/view/qt/AssignmentView.hpp
+    include/view/qt/CourseView.hpp
+    include/view/qt/FormDialog.hpp
+    include/view/qt/MainWindow.hpp
+    include/view/qt/PaletteWatcher.hpp
+    include/view/qt/StyleManager.hpp
+    include/view/qt/TermView.hpp
+)
+
+target_link_libraries(CourseCompanion_gui
+    PUBLIC
+        CourseCompanion_lib
+        Qt6::Widgets
+)
+
 if(NOT BUILD_TESTING)
-    find_package(Qt6 REQUIRED COMPONENTS Widgets)
-
-    add_library(CourseCompanion_gui OBJECT
-        src/view/cli/CliView.cpp
-        src/view/qt/AssignmentView.cpp
-        src/view/qt/CourseView.cpp
-        src/view/qt/FormDialog.cpp
-        src/view/qt/MainWindow.cpp
-        src/view/qt/TermView.cpp
-    )
-
-    target_include_directories(CourseCompanion_gui PUBLIC include)
-
-    set_target_properties(CourseCompanion_gui PROPERTIES
-        AUTOMOC_MOC_OPTIONS ""
-    )
-    target_sources(CourseCompanion_gui PRIVATE
-        include/view/qt/AssignmentView.hpp
-        include/view/qt/CourseView.hpp
-        include/view/qt/FormDialog.hpp
-        include/view/qt/MainWindow.hpp
-        include/view/qt/PaletteWatcher.hpp
-        include/view/qt/StyleManager.hpp
-        include/view/qt/TermView.hpp
-    )
-
-    target_link_libraries(CourseCompanion_gui
-        PUBLIC
-            CourseCompanion_lib
-            Qt6::Widgets
-    )
-
     add_executable(CourseCompanion src/main.cpp)
     target_include_directories(CourseCompanion PRIVATE include)
     target_link_libraries(CourseCompanion PRIVATE CourseCompanion_gui CourseCompanion_lib)

--- a/client/scripts/run-tests
+++ b/client/scripts/run-tests
@@ -8,9 +8,13 @@ usage() {
     exit 1
 }
 
-if [ -f .env ]; then
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$SCRIPT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
     set -a
-    source .env
+    set +u
+    source "$ENV_FILE"
+    set -u
     set +a
 fi
 

--- a/client/scripts/run-tests
+++ b/client/scripts/run-tests
@@ -8,6 +8,12 @@ usage() {
     exit 1
 }
 
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
 OUTPUT_DIR="${OUTPUT_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/tests/output_logs"}"
 mkdir -p "$OUTPUT_DIR"
 

--- a/client/src/view/qt/AssignmentView.cpp
+++ b/client/src/view/qt/AssignmentView.cpp
@@ -13,11 +13,10 @@
  * is planned but not yet implemented.
  */
 
-#include "view/qt/FormDialog.hpp"
-
 #include <QDebug>
 #include <QMessageBox>
 #include <QStringList>
+#include "view/qt/FormDialog.hpp"
 
 AssignmentView::AssignmentView(QWidget* parent) : QWidget(parent) {
     mainLayout_ = new QVBoxLayout(this);

--- a/client/src/view/qt/CourseView.cpp
+++ b/client/src/view/qt/CourseView.cpp
@@ -11,14 +11,13 @@
  * Note: the current Qt implementation uses placeholder data; controller wiring is planned but not yet implemented.
  */
 
-#include "view/qt/FormDialog.hpp"
-
 #include <QDate>
 #include <QDebug>
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QStackedLayout>
+#include "view/qt/FormDialog.hpp"
 
 static const QString kBtnActive =
     "QPushButton {"

--- a/client/src/view/qt/TermView.cpp
+++ b/client/src/view/qt/TermView.cpp
@@ -11,12 +11,12 @@
  * Note: the current Qt implementation uses placeholder data; controller wiring is planned but not yet implemented.
  */
 
-#include "view/qt/FormDialog.hpp"
-
-#include <QDate>
 #include <QDebug>
+#include <QMessageBox>
 #include <QPushButton>
 #include <QStackedLayout>
+#include "utils/utils.hpp"
+#include "view/qt/FormDialog.hpp"
 
 TermView::TermView(QWidget* parent) : QWidget(parent) {
     mainLayout_ = new QVBoxLayout(this);
@@ -310,12 +310,20 @@ void TermView::onAddTerm() {
     if (dlg.exec() != QDialog::Accepted)
         return;
 
-    // TODO: wire to TermController::addTerm once controller is connected
-    qDebug() << "Add Term:"
-             << dlg.textValue("title")
-             << dlg.dateValue("startDate").toString("yyyy-MM-dd")
-             << dlg.dateValue("endDate").toString("yyyy-MM-dd")
-             << dlg.boolValue("active");
+    submitAddTerm(dlg.textValue("title"), dlg.dateValue("startDate"), dlg.dateValue("endDate"), dlg.boolValue("active"));
+}
+
+void TermView::submitAddTerm(const QString& title, const QDate& startDate, const QDate& endDate, bool active) {
+    try {
+        controller_.addTerm(
+            title.toStdString(),
+            utils::parseDateFromQt(startDate),
+            utils::parseDateFromQt(endDate),
+            active
+        );
+    } catch (const std::logic_error& e) {
+        QMessageBox::warning(this, "Add Term Failed", QString::fromStdString(e.what()));
+    }
 }
 
 void TermView::onAddCourse() {

--- a/client/src/view/qt/TermView.cpp
+++ b/client/src/view/qt/TermView.cpp
@@ -12,10 +12,8 @@
  */
 
 #include <QDebug>
-#include <QMessageBox>
 #include <QPushButton>
 #include <QStackedLayout>
-#include "utils/utils.hpp"
 #include "view/qt/FormDialog.hpp"
 
 TermView::TermView(QWidget* parent) : QWidget(parent) {
@@ -310,20 +308,12 @@ void TermView::onAddTerm() {
     if (dlg.exec() != QDialog::Accepted)
         return;
 
-    submitAddTerm(dlg.textValue("title"), dlg.dateValue("startDate"), dlg.dateValue("endDate"), dlg.boolValue("active"));
-}
-
-void TermView::submitAddTerm(const QString& title, const QDate& startDate, const QDate& endDate, bool active) {
-    try {
-        controller_.addTerm(
-            title.toStdString(),
-            utils::parseDateFromQt(startDate),
-            utils::parseDateFromQt(endDate),
-            active
-        );
-    } catch (const std::logic_error& e) {
-        QMessageBox::warning(this, "Add Term Failed", QString::fromStdString(e.what()));
-    }
+    // TODO: wire to TermController::addTerm once controller is connected
+    qDebug() << "Add Term:"
+             << dlg.textValue("title")
+             << dlg.dateValue("startDate").toString("yyyy-MM-dd")
+             << dlg.dateValue("endDate").toString("yyyy-MM-dd")
+             << dlg.boolValue("active");
 }
 
 void TermView::onAddCourse() {

--- a/client/tests/unit/CMakeLists.txt
+++ b/client/tests/unit/CMakeLists.txt
@@ -47,13 +47,13 @@ enable_coverage(TermTests)
 # add_test(NAME CourseViewTests COMMAND CourseViewTests)
 # enable_coverage(CourseViewTests)
 
-add_executable(TermViewTests
-    view/qt/TermViewTests.cpp
-    view/qt/QtTestMain.cpp
-)
-target_link_libraries(TermViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest Qt6::Test)
-add_test(NAME TermViewTests COMMAND TermViewTests)
-enable_coverage(TermViewTests)
+# add_executable(TermViewTests
+#     view/qt/TermViewTests.cpp
+#     view/qt/QtTestMain.cpp
+# )
+# target_link_libraries(TermViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest Qt6::Test)
+# add_test(NAME TermViewTests COMMAND TermViewTests)
+# enable_coverage(TermViewTests)
 
 add_executable(CliViewTests view/cli/CliViewTests.cpp)
 target_link_libraries(CliViewTests PRIVATE CourseCompanion_cli GTest::gtest_main)

--- a/client/tests/unit/CMakeLists.txt
+++ b/client/tests/unit/CMakeLists.txt
@@ -74,7 +74,7 @@ foreach(test_target
     TermControllerTests
     # AssignmentViewTests
     # CourseViewTests
-    TermViewTests
+    # TermViewTests
     CliViewTests
     UtilsTests
 )

--- a/client/tests/unit/CMakeLists.txt
+++ b/client/tests/unit/CMakeLists.txt
@@ -31,18 +31,27 @@ target_link_libraries(TermTests PRIVATE CourseCompanion_lib GTest::gtest_main)
 add_test(NAME TermTests COMMAND TermTests)
 enable_coverage(TermTests)
 
-# add_executable(AssignmentViewTests view/qt/AssignmentViewTests.cpp)
-# target_link_libraries(AssignmentViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest_main Qt6::Test)
+# add_executable(AssignmentViewTests
+    # view/qt/AssignmentViewTests.cpp
+    # view/qt/QtTestMain.cpp
+# )
+# target_link_libraries(AssignmentViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest Qt6::Test)
 # add_test(NAME AssignmentViewTests COMMAND AssignmentViewTests)
 # enable_coverage(AssignmentViewTests)
 
-# add_executable(CourseViewTests view/qt/CourseViewTests.cpp)
-# target_link_libraries(CourseViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest_main Qt6::Test)
+# add_executable(CourseViewTests
+    # view/qt/CourseViewTests.cpp
+    # view/qt/QtTestMain.cpp
+# )
+# target_link_libraries(CourseViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest Qt6::Test)
 # add_test(NAME CourseViewTests COMMAND CourseViewTests)
 # enable_coverage(CourseViewTests)
 
-add_executable(TermViewTests view/qt/TermViewTests.cpp)
-target_link_libraries(TermViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest_main Qt6::Test)
+add_executable(TermViewTests
+    view/qt/TermViewTests.cpp
+    view/qt/QtTestMain.cpp
+)
+target_link_libraries(TermViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest Qt6::Test)
 add_test(NAME TermViewTests COMMAND TermViewTests)
 enable_coverage(TermViewTests)
 

--- a/client/tests/unit/CMakeLists.txt
+++ b/client/tests/unit/CMakeLists.txt
@@ -31,6 +31,21 @@ target_link_libraries(TermTests PRIVATE CourseCompanion_lib GTest::gtest_main)
 add_test(NAME TermTests COMMAND TermTests)
 enable_coverage(TermTests)
 
+# add_executable(AssignmentViewTests view/qt/AssignmentViewTests.cpp)
+# target_link_libraries(AssignmentViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest_main Qt6::Test)
+# add_test(NAME AssignmentViewTests COMMAND AssignmentViewTests)
+# enable_coverage(AssignmentViewTests)
+
+# add_executable(CourseViewTests view/qt/CourseViewTests.cpp)
+# target_link_libraries(CourseViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest_main Qt6::Test)
+# add_test(NAME CourseViewTests COMMAND CourseViewTests)
+# enable_coverage(CourseViewTests)
+
+add_executable(TermViewTests view/qt/TermViewTests.cpp)
+target_link_libraries(TermViewTests PRIVATE CourseCompanion_gui CourseCompanion_lib GTest::gtest_main Qt6::Test)
+add_test(NAME TermViewTests COMMAND TermViewTests)
+enable_coverage(TermViewTests)
+
 add_executable(CliViewTests view/cli/CliViewTests.cpp)
 target_link_libraries(CliViewTests PRIVATE CourseCompanion_cli GTest::gtest_main)
 add_test(NAME CliViewTests COMMAND CliViewTests)
@@ -42,13 +57,16 @@ add_test(NAME UtilsTests COMMAND UtilsTests)
 enable_coverage(UtilsTests)
 
 foreach(test_target
-    CliViewTests
     AssignmentTests
     CourseTests
     TermTests
     AssignmentControllerTests
     CourseControllerTests
     TermControllerTests
+    # AssignmentViewTests
+    # CourseViewTests
+    TermViewTests
+    CliViewTests
     UtilsTests
 )
     set_target_properties(${test_target} PROPERTIES


### PR DESCRIPTION
# Pull Request

## Description

This PR changes CMakeLists.txt in the root folder to allow views to be tested with gtest. It removes some conditions of BUILD_TESTING to enable this.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Refactor
-   [ ] Documentation

## Related Issue

Resolves [CC-134](https://geoffreyagustin.atlassian.net/browse/CC-134)

## Checklist

-   [x] I have tested this code
-   [x] I have added/updated unit tests
-   [x] I have updated documentation if needed
-   [x] CI/CD checks pass
-   [x] Code follows coding standards


[CC-134]: https://geoffreyagustin.atlassian.net/browse/CC-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ